### PR TITLE
Fix Node restart logic and add tests

### DIFF
--- a/enable_root.js
+++ b/enable_root.js
@@ -3,7 +3,6 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const process = require('process');
 
 const SSH_CONFIG = '/etc/ssh/sshd_config';
 const SCRIPT_PATH = path.resolve(__filename);
@@ -19,8 +18,16 @@ function runCommand(command) {
     try {
         execSync(command, { stdio: 'inherit' });
     } catch (error) {
-        logMessage(`Error: Command '${command}' failed with exit code ${error.status}`);
-        process.exit(1);
+        throw new Error(`Command '${command}' failed with exit code ${error.status}`);
+    }
+}
+
+function isServiceActive(service) {
+    try {
+        execSync(`systemctl is-active --quiet ${service}`, { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
     }
 }
 
@@ -36,17 +43,14 @@ function setRootPassword() {
 }
 
 function restartSshService() {
-    try {
+    if (isServiceActive('sshd')) {
         runCommand('sudo systemctl restart sshd');
         logMessage('sshd service restarted successfully.');
-    } catch {
-        try {
-            runCommand('sudo systemctl restart ssh');
-            logMessage('ssh service restarted successfully.');
-        } catch {
-            logMessage('Error: Neither sshd nor ssh service found on this system.');
-            process.exit(1);
-        }
+    } else if (isServiceActive('ssh')) {
+        runCommand('sudo systemctl restart ssh');
+        logMessage('ssh service restarted successfully.');
+    } else {
+        throw new Error('Neither sshd nor ssh service found on this system.');
     }
 }
 
@@ -55,18 +59,35 @@ function deleteScript() {
         fs.unlinkSync(SCRIPT_PATH);
         logMessage(`Script file ${SCRIPT_PATH} has been deleted.`);
     } catch (error) {
-        logMessage(`Error: Failed to delete the script file at ${SCRIPT_PATH} - ${error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to delete the script file at ${SCRIPT_PATH} - ${error.message}`);
     }
 }
 
 function main() {
-    logMessage('Starting SSH configuration update script.');
-    updateSshConfig(SSH_CONFIG);
-    setRootPassword();
-    restartSshService();
-    logMessage('Root login via SSH has been enabled and SSH service restarted.');
-    deleteScript();
+    try {
+        logMessage('Starting SSH configuration update script.');
+        updateSshConfig(SSH_CONFIG);
+        setRootPassword();
+        restartSshService();
+        logMessage('Root login via SSH has been enabled and SSH service restarted.');
+        deleteScript();
+    } catch (error) {
+        logMessage(`Error: ${error.message}`);
+        process.exit(1);
+    }
 }
 
-main();
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    runCommand,
+    isServiceActive,
+    restartSshService,
+    updateSshConfig,
+    setRootPassword,
+    deleteScript,
+    main,
+    logMessage,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "enable-root-ssh-access",
+  "version": "1.0.0",
+  "description": "Scripts to enable root login via SSH",
+  "main": "enable_root.js",
+  "scripts": {
+    "test": "node test/test.js"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,65 @@
+const assert = require('assert');
+const child_process = require('child_process');
+
+// patch execSync before requiring the script so that internal calls use the mock
+function withExecSync(mockFn, fn) {
+  const original = child_process.execSync;
+  child_process.execSync = (...args) => mockFn(...args);
+  delete require.cache[require.resolve('../enable_root.js')];
+  const script = require('../enable_root.js');
+  script.logMessage = () => {};
+  try {
+    fn(script);
+  } finally {
+    child_process.execSync = original;
+    delete require.cache[require.resolve('../enable_root.js')];
+  }
+}
+
+function testRestartSshService() {
+  let commands = [];
+  // sshd active
+  withExecSync((cmd) => {
+    commands.push(cmd);
+    if (cmd.startsWith('systemctl is-active')) {
+      if (cmd.includes('sshd')) return ''; // success
+      throw new Error('inactive');
+    }
+    return '';
+  }, (script) => {
+    script.restartSshService();
+  });
+  assert(commands.includes('sudo systemctl restart sshd'));
+
+  // ssh active when sshd inactive
+  commands = [];
+  withExecSync((cmd) => {
+    commands.push(cmd);
+    if (cmd.startsWith('systemctl is-active')) {
+      if (cmd.includes('sshd')) throw new Error('inactive');
+      return ''; // ssh active
+    }
+    return '';
+  }, (script) => {
+    script.restartSshService();
+  });
+  assert(commands.includes('sudo systemctl restart ssh'));
+
+  // neither active
+  let errorCaught = false;
+  withExecSync((cmd) => {
+    if (cmd.startsWith('systemctl is-active')) {
+      throw new Error('inactive');
+    }
+  }, (script) => {
+    try {
+      script.restartSshService();
+    } catch (e) {
+      errorCaught = true;
+    }
+  });
+  assert(errorCaught, 'Expected error when no SSH service is active');
+}
+
+testRestartSshService();
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- fix fallback logic for restarting SSH services in `enable_root.js`
- export functions for easier testing
- add Node-based unit tests
- provide `package.json` for running tests